### PR TITLE
fix: build C++ extensions during editable installs

### DIFF
--- a/data_juicer/ops/deduplicator/ray_bts_minhash_cpp_deduplicator.py
+++ b/data_juicer/ops/deduplicator/ray_bts_minhash_cpp_deduplicator.py
@@ -317,9 +317,14 @@ class MinhashCalculator:
         elif self.tokenization == "punctuation":
             self.tokenization_func = lambda x: [s.encode("utf-8") for s in self.punctuation_pattern.split(x)]
         elif self.tokenization == "space":
-            from .tokenize import split_on_whitespace
+            try:
+                from .tokenize import split_on_whitespace
 
-            self.tokenization_func = split_on_whitespace
+                self.tokenization_func = split_on_whitespace
+            except ImportError as e:
+                logger.error(f"Failed to import split_on_whitespace from tokenize module: {e}")
+                logger.error("This usually indicates the C++ extensions were not built during installation.")
+                raise
         elif self.tokenization == "sentencepiece":
             self.tokenization_func = lambda x: self.tokenizer.encode(x, out_type=str)
         else:
@@ -353,8 +358,14 @@ class MinhashCalculator:
         self.empty_hash_table_id = int(MAX_HASH % self.union_find_parallel_num)
 
     def calc_minhash(self, text_list: pa.Array, uid_begin: int, thread_num: int = 4) -> pa.Table:
-        from .minhash import calc_minhash_batch_c
-        from .tokenize import n_grams
+        try:
+            from .minhash import calc_minhash_batch_c
+            from .tokenize import n_grams
+        except ImportError as e:
+            logger.error(f"Failed to import C++ extensions: {e}")
+            logger.error("This usually indicates the C++ extensions were not built during installation.")
+            logger.error("Please ensure you have built the extensions with: pip install -e . --verbose")
+            raise
 
         tokens = [n_grams(self.tokenization_func(text.as_py()), self.window_size) for text in text_list]
         pairs = calc_minhash_batch_c(

--- a/hatch_build.py
+++ b/hatch_build.py
@@ -10,12 +10,10 @@ class CustomBuildHook(BuildHookInterface):
     """Custom build hook to compile C++ extensions."""
 
     def initialize(self, version, build_data):
-        """Compile C++ extensions before building the wheel."""
-        if self.target_name not in ("wheel", "sdist"):
-            return
-
-        # Only compile for wheel builds; skip on macOS (C++/OpenMP toolchain issues)
-        if self.target_name == "wheel" and sys.platform != "darwin":
+        """Compile C++ extensions before building the wheel or during editable installs."""
+        # Build extensions for wheel, sdist, and editable installs
+        # Skip on macOS (C++/OpenMP toolchain issues)
+        if self.target_name in ("wheel", "sdist", "editable") and sys.platform != "darwin":
             self._build_extensions()
 
     def _build_extensions(self):


### PR DESCRIPTION
**Closing this PR — the issue does not reproduce in practice.**

After testing on a fresh editable install, the C++ extensions are in fact built correctly. This was a false positive from the gap analysis pipeline. No code changes needed.